### PR TITLE
snap: use --devmode when trying to install

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,5 +29,5 @@ jobs:
         name: snap
         path: ${{ steps.snapcraft.outputs.snap }}
     - run: |
-        sudo snap install --dangerous --classic ${{ steps.snapcraft.outputs.snap }}
+        sudo snap install --dangerous --devmode ${{ steps.snapcraft.outputs.snap }}
         jenviz -h


### PR DESCRIPTION
That fixes the current test failure:

Run sudo snap install --dangerous --classic jenviz_0+git.b1445e9_amd64.snap
  sudo snap install --dangerous --classic jenviz_0+git.b1445e9_amd64.snap
  jenviz -h
  shell: /usr/bin/bash -e {0}
error: snap "jenviz_0+git.b1445e9_amd64.snap" requires devmode or confinement
       override
Error: Process completed with exit code 1.