### PR TITLE
setup.cfg: Fix long description

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ url = https://github.com/toabctl/jenviz
 author = Thomas Bechtold
 author_email = thomasbechtold@jpberlin.de
 license = Apache-2.0
-long-description = README.rst
+long-description = file: README.rst
 classifiers =
   Programming Language :: Python :: 3.7
   Programming Language :: Python :: 3.8


### PR DESCRIPTION
Instead of showing the text "README.rst", read that file and show its
content.